### PR TITLE
Option to disable z and/or xy homing

### DIFF
--- a/OpenbuildsGRBL.cps
+++ b/OpenbuildsGRBL.cps
@@ -48,6 +48,7 @@ properties =
 	spindleTwoDirections : false,		// true : spindle can rotate clockwise and counterclockwise, will send M3 and M4. false : spindle can only go clockwise, will only send M3
 	hasCoolant : false,					// true : machine uses the coolant output, M8 M9 will be sent. false : coolant output not connected, so no M8 M9 will be sent
 	hasSpeedDial : true,				// true : the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6. false : other spindle
+	shouldHomeZ : true,					// true : the machine should go to a specific z coordinate at start and end of gcode
 	machineHomeZ : -10,					// absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y
 	machineHomeX : -10,
 	machineHomeY : -10
@@ -59,6 +60,7 @@ propertyDefinitions =
 	spindleTwoDirections: {title: "Bidirectional Spindle", description: "True if the spindle can rotate clockwise and counterclockwise, will send M3 and M4. False if the spindle can only go clockwise, will only send M3.", type: "boolean"},
 	hasCoolant: {title: "Has Coolant", description: "True if the machine uses the coolant output (M8 M9 will be sent). False if the coolant output not connected.", type: "boolean"},
 	hasSpeedDial: {title: "Has Speed Dial", description: "True if the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6.", type: "boolean"},
+	shouldHomeZ: {title: "Use Z Home Position", description: "True if the machine should go to a specific z coordinate at start and end of gcode.", type: "boolean"},
 	machineHomeZ: {title: "Z Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeX: {title: "X Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeY: {title: "Y Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
@@ -298,7 +300,7 @@ function onSection()
 	if(isFirstSection())
 		{
 		writeBlock(gAbsIncModal.format(90));	// Set to absolute coordinates
-		if (isMilling())
+		if (isMilling() && properties.shouldHomeZ)
 			{
 			writeBlock(gFormat.format(53), gMotionModal.format(0), "Z" + xyzFormat.format(properties.machineHomeZ));	// Retract spindle to Machine Z Home
 			}
@@ -457,7 +459,7 @@ function onSectionEnd()
 function onClose()
 	{
 	writeBlock(gAbsIncModal.format(90));	// Set to absolute coordinates for the following moves
-	if (isMilling())						// For CNC we move the Z-axis up, for lasercutter it's not needed
+	if (isMilling() && properties.shouldHomeZ)	        // For CNC we move the Z-axis up, for lasercutter it's not needed
 		{
 		writeBlock(gAbsIncModal.format(90), gFormat.format(53), gMotionModal.format(0), "Z" + xyzFormat.format(properties.machineHomeZ));	// Retract spindle to Machine Z Home
 		}

--- a/OpenbuildsGRBL.cps
+++ b/OpenbuildsGRBL.cps
@@ -49,6 +49,7 @@ properties =
 	spindleTwoDirections : false,		// true : spindle can rotate clockwise and counterclockwise, will send M3 and M4. false : spindle can only go clockwise, will only send M3
 	hasCoolant : false,					// true : machine uses the coolant output, M8 M9 will be sent. false : coolant output not connected, so no M8 M9 will be sent
 	hasSpeedDial : true,				// true : the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6. false : other spindle
+	shouldHomeZ : true,					// true : the machine should go to a specific z coordinate at start and end of gcode
 	machineHomeZ : -10,					// absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y
 	machineHomeX : -10,
 	machineHomeY : -10
@@ -60,6 +61,7 @@ propertyDefinitions =
 	spindleTwoDirections: {title: "Bidirectional Spindle", description: "True if the spindle can rotate clockwise and counterclockwise, will send M3 and M4. False if the spindle can only go clockwise, will only send M3.", type: "boolean"},
 	hasCoolant: {title: "Has Coolant", description: "True if the machine uses the coolant output (M8 M9 will be sent). False if the coolant output not connected.", type: "boolean"},
 	hasSpeedDial: {title: "Has Speed Dial", description: "True if the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6.", type: "boolean"},
+	shouldHomeZ: {title: "Use Z Home Position", description: "True if the machine should go to a specific z coordinate at start and end of gcode.", type: "boolean"},
 	machineHomeZ: {title: "Z Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeX: {title: "X Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeY: {title: "Y Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
@@ -299,7 +301,7 @@ function onSection()
 	if(isFirstSection())
 		{
 		writeBlock(gAbsIncModal.format(90));	// Set to absolute coordinates
-		if (isMilling())
+		if (isMilling() && properties.shouldHomeZ)
 			{
 			writeBlock(gFormat.format(53), gMotionModal.format(0), "Z" + xyzFormat.format(properties.machineHomeZ));	// Retract spindle to Machine Z Home
 			}
@@ -458,7 +460,7 @@ function onSectionEnd()
 function onClose()
 	{
 	writeBlock(gAbsIncModal.format(90));	// Set to absolute coordinates for the following moves
-	if (isMilling())						// For CNC we move the Z-axis up, for lasercutter it's not needed
+	if (isMilling() && properties.shouldHomeZ)	        // For CNC we move the Z-axis up, for lasercutter it's not needed
 		{
 		writeBlock(gAbsIncModal.format(90), gFormat.format(53), gMotionModal.format(0), "Z" + xyzFormat.format(properties.machineHomeZ));	// Retract spindle to Machine Z Home
 		}

--- a/OpenbuildsGRBL.cps
+++ b/OpenbuildsGRBL.cps
@@ -49,6 +49,7 @@ properties =
 	hasCoolant : false,					// true : machine uses the coolant output, M8 M9 will be sent. false : coolant output not connected, so no M8 M9 will be sent
 	hasSpeedDial : true,				// true : the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6. false : other spindle
 	shouldHomeZ : true,					// true : the machine should go to a specific z coordinate at start and end of gcode
+	shouldHomeXY : true,					// true : the machine should go to a specific xy coordinate at end of gcode
 	machineHomeZ : -10,					// absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y
 	machineHomeX : -10,
 	machineHomeY : -10
@@ -61,6 +62,7 @@ propertyDefinitions =
 	hasCoolant: {title: "Has Coolant", description: "True if the machine uses the coolant output (M8 M9 will be sent). False if the coolant output not connected.", type: "boolean"},
 	hasSpeedDial: {title: "Has Speed Dial", description: "True if the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6.", type: "boolean"},
 	shouldHomeZ: {title: "Use Z Home Position", description: "True if the machine should go to a specific z coordinate at start and end of gcode.", type: "boolean"},
+	shouldHomeXY: {title: "Use XY Home Position", description: "True if the machine should go to a specific xy coordinate at end of gcode.", type: "boolean"},
 	machineHomeZ: {title: "Z Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeX: {title: "X Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeY: {title: "Y Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
@@ -469,8 +471,10 @@ function onClose()
 		writeBlock(mFormat.format(9));																				// Stop Coolant
 		}
 	onDwell(properties.spindleOnOffDelay);																			// Wait for spindle to stop
-	writeBlock(gAbsIncModal.format(90), gFormat.format(53), gMotionModal.format(0), "X" + xyzFormat.format(properties.machineHomeX), "Y" + xyzFormat.format(properties.machineHomeY));	// Return to home position
-
+	if (properties.shouldHomeXY)
+		{
+		writeBlock(gAbsIncModal.format(90), gFormat.format(53), gMotionModal.format(0), "X" + xyzFormat.format(properties.machineHomeX), "Y" + xyzFormat.format(properties.machineHomeY));	// Return to home position
+		}
 	writeBlock(mFormat.format(30));																					// Program End
 	writeln("%");																									// EndOfFile marker - GRBL doesn't use it / ignores it, but it's so much tradition, so I left it in..
 	}

--- a/OpenbuildsGRBL.cps
+++ b/OpenbuildsGRBL.cps
@@ -50,6 +50,7 @@ properties =
 	hasCoolant : false,					// true : machine uses the coolant output, M8 M9 will be sent. false : coolant output not connected, so no M8 M9 will be sent
 	hasSpeedDial : true,				// true : the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6. false : other spindle
 	shouldHomeZ : true,					// true : the machine should go to a specific z coordinate at start and end of gcode
+	shouldHomeXY : true,					// true : the machine should go to a specific xy coordinate at end of gcode
 	machineHomeZ : -10,					// absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y
 	machineHomeX : -10,
 	machineHomeY : -10
@@ -62,6 +63,7 @@ propertyDefinitions =
 	hasCoolant: {title: "Has Coolant", description: "True if the machine uses the coolant output (M8 M9 will be sent). False if the coolant output not connected.", type: "boolean"},
 	hasSpeedDial: {title: "Has Speed Dial", description: "True if the spindle is of type Makita RT0700, Dewalt 611 with a Dial to set speeds 1-6.", type: "boolean"},
 	shouldHomeZ: {title: "Use Z Home Position", description: "True if the machine should go to a specific z coordinate at start and end of gcode.", type: "boolean"},
+	shouldHomeXY: {title: "Use XY Home Position", description: "True if the machine should go to a specific xy coordinate at end of gcode.", type: "boolean"},
 	machineHomeZ: {title: "Z Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeX: {title: "X Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
 	machineHomeY: {title: "Y Home Position", description: "Absolute machine coordinates where the machine will move to at the end of the job - first retracting Z, then moving home X Y", type: "number"},
@@ -470,8 +472,10 @@ function onClose()
 		writeBlock(mFormat.format(9));																				// Stop Coolant
 		}
 	onDwell(properties.spindleOnOffDelay);																			// Wait for spindle to stop
-	writeBlock(gAbsIncModal.format(90), gFormat.format(53), gMotionModal.format(0), "X" + xyzFormat.format(properties.machineHomeX), "Y" + xyzFormat.format(properties.machineHomeY));	// Return to home position
-
+	if (properties.shouldHomeXY)
+		{
+		writeBlock(gAbsIncModal.format(90), gFormat.format(53), gMotionModal.format(0), "X" + xyzFormat.format(properties.machineHomeX), "Y" + xyzFormat.format(properties.machineHomeY));	// Return to home position
+		}
 	writeBlock(mFormat.format(30));																					// Program End
 	writeln("%");																									// EndOfFile marker - GRBL doesn't use it / ignores it, but it's so much tradition, so I left it in..
 	}


### PR DESCRIPTION
This PR provides an option to disable homing on the Z at the beginning and end of the generated GCode as well as an option to disable XY homing at the end of the generated GCode.

My machine (a [MPCNC](https://www.v1engineering.com/assembly/)) doesn't have Z endstops -- so it's unable to position itself correctly with machine coordinates on the Z axis. That means the `G53 G0 Z-10` at the beginning of the GCode and the `G53 Z-10` at the end of the GCode (where `properties.machineHomeZ = -10`) will cause the machine to go to a random Z height, sometimes causing a collision with the workpiece. 

Additionally, sometimes when making a cutting multiple small pieces, I don't want the machine to move away from the workpiece at the end of the GCode. In those cases, it's helpful to be able to disable XY homing as well.